### PR TITLE
Remove proc_macro_hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change log
+
+All notable changes to this project will be documented in this file.
+
+## main branch
+
+### Changes
+
+* Removed use of [proc_macro_hack][], which hasn’t been needed since Rust 1.45
+  (released in July 2020).
+* Added this change log.
+
+[proc_macro_hack]: https://docs.rs/proc-macro-hack/0.5.19/proc_macro_hack/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 assertify_proc_macros = { version = "0.6.1", path = "assertify_proc_macros" }
-proc-macro-hack = "0.5"
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ thread 'tests::concat_literals' panicked at 'failed: concat("a", "b") == "aX"
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ```
 
+## Compatibility
+
+This requires at least Rust version 1.45 (released in July 2020).
+
 ## License
 
 This project dual-licensed under the Apache 2 and MIT licenses. You may choose

--- a/assertify_proc_macros/Cargo.toml
+++ b/assertify_proc_macros/Cargo.toml
@@ -15,7 +15,6 @@ maintenance = { status = "actively-developed" }
 proc-macro = true
 
 [dependencies]
-proc-macro-hack = "0.5"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }

--- a/assertify_proc_macros/src/lib.rs
+++ b/assertify_proc_macros/src/lib.rs
@@ -1,9 +1,7 @@
 //! Do not use this crate directly. Instead use the wrapper crate,
 //! [assertify.](../assertify/macro.assertify.html)
 
-extern crate proc_macro;
 use proc_macro2::TokenStream;
-use proc_macro_hack::proc_macro_hack;
 use quote::{quote, ToTokens};
 use syn::parse::{self, Parse, ParseStream};
 use syn::parse_macro_input;
@@ -95,7 +93,7 @@ impl Parse for Testified {
 ///
 /// Do not use this directly. Instead, use
 /// [assertify::assertify](../assertify/macro.assertify.html).
-#[proc_macro_hack]
+#[proc_macro]
 pub fn assertify(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let assertified = parse_macro_input!(input as Assertified);
     quote!(#assertified).into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,6 @@
 //! }
 //! ```
 
-use proc_macro_hack::proc_macro_hack;
-
 /// Assert an expression is true or give a useful error when it isn’t.
 ///
 /// If the expression contains a comparison, e.g. `==`, then the failure message
@@ -63,7 +61,6 @@ use proc_macro_hack::proc_macro_hack;
 /// ---- tests::simple_literal stdout ----
 /// thread 'tests::simple_literal' panicked at 'failed: false', src/lib.rs:131:9
 /// ```
-#[proc_macro_hack]
 pub use assertify_proc_macros::assertify;
 
 /// Create a test function from an expression.

--- a/tests/trybuild-failures/not_binary_expression.stderr
+++ b/tests/trybuild-failures/not_binary_expression.stderr
@@ -6,5 +6,3 @@ error[E0308]: mismatched types
   |     |          |
   |     |          expected `bool`, found `&str`
   |     expected due to this
-  |
-  = note: this error originates in the macro `proc_macro_call` which comes from the expansion of the macro `assertify` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/trybuild-failures/not_comparison.stderr
+++ b/tests/trybuild-failures/not_comparison.stderr
@@ -6,5 +6,3 @@ error[E0308]: mismatched types
   |     |          |
   |     |          expected `bool`, found integer
   |     expected due to this
-  |
-  = note: this error originates in the macro `proc_macro_call` which comes from the expansion of the macro `assertify` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
[proc_macro_hack][] hasn’t been needed since Rust 1.45, which was released on July 16, 2020. This removes it.

[proc_macro_hack]: https://docs.rs/proc-macro-hack/0.5.19/proc_macro_hack/