### PR TITLE
0.7.0: deprecate in favor of assert2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 0.7.0 (2022-12-11)
 
 ### Changes
 
+* Decided to deprecate. The [assert2][] crate’s macros are strictly better than
+  this crate’s `assertify!`, and the `testify!` macro is easy to replace.
 * Consolidated old assertify_proc_macros crate into this crate. This crate only
   defines the procedural macros and does not actually use them, so there is no
   need for a sub-crate.
@@ -14,3 +16,4 @@ All notable changes to this project will be documented in this file.
 * Added this change log.
 
 [proc_macro_hack]: https://docs.rs/proc-macro-hack/0.5.19/proc_macro_hack/
+[assert2]: https://docs.rs/assert2/0.3.7/assert2/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "assertify"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Daniel Parks <oss-assertify@demonhorse.org>"]
-description = "Clearer assertions and tests for expressions"
+description = "Deprecated: use assert2 for better assertions"
 homepage = "https://github.com/danielparks/assertify"
 repository = "https://github.com/danielparks/assertify"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
-# Assertify and Testify
+# Deprecated — use [assert2][]
 
-This provides two convenience macros to make tests with easy to understand
-failure messages from simple Rust expressions.
+Use [assert2][] instead of this crate. `assertify!` can be replaced by the
+more capable [`assert2::assert!`][] everywhere, and `testify!` can implemented
+with a short macro:
+
+```rust
+macro_rules! testify {
+    ($name:ident, $($test:tt)+) => {
+        #[test]
+        fn $name() {
+            ::assert2::assert!($($test)+);
+        }
+    };
+}
+```
 
 ### `assertify!(expr)`
+
+**Deprecated**: use [`assert2::assert!`][].
 
 Generates an assertion for `expr` with a friendly failure message. If `expr` is
 a binary expression, the actual value should be on the left and the expected
@@ -44,6 +58,19 @@ thread 'tests::simple_eq_traditional' panicked at 'assertion failed: `(left == r
 
 ### `testify!(name, expr)`
 
+**Deprecated**: Use the following:
+
+```rust
+macro_rules! testify {
+    ($name:ident, $($test:tt)+) => {
+        #[test]
+        fn $name() {
+            ::assert2::assert!($($test)+);
+        }
+    };
+}
+```
+
 Generates a test function named `name` that asserts that `expr` is true.
 
 ```rust
@@ -78,3 +105,7 @@ to use either.
 Unless you explicitly state otherwise, any contribution you submit as defined
 in the Apache 2.0 license shall be dual licensed as above, without any
 additional terms or conditions.
+
+
+[assert2]: https://crates.io/crates/assert2
+[`assert2::assert!`]: https://docs.rs/assert2/0.3.7/assert2/macro.assert.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ impl Parse for Testified {
 /// ---- tests::simple_literal stdout ----
 /// thread 'tests::simple_literal' panicked at 'failed: false', src/lib.rs:131:9
 /// ```
+#[deprecated(since = "0.7.0", note = "use assert2::assert! instead")]
 #[proc_macro]
 pub fn assertify(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let assertified = parse_macro_input!(input as Assertified);

--- a/tests/assertify.rs
+++ b/tests/assertify.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use assertify::assertify;
 
 #[test]

--- a/tests/testify.rs
+++ b/tests/testify.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use assertify::testify;
 
 testify!(simple_eq, 1 + 2 == 3);

--- a/tests/trybuild-failures/not_binary_expression.rs
+++ b/tests/trybuild-failures/not_binary_expression.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use assertify::assertify;
 
 fn main() {

--- a/tests/trybuild-failures/not_binary_expression.stderr
+++ b/tests/trybuild-failures/not_binary_expression.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
- --> $DIR/not_binary_expression.rs:4:16
+ --> $DIR/not_binary_expression.rs:6:16
   |
-4 |     assertify!("foo");
+6 |     assertify!("foo");
   |     -----------^^^^^-
   |     |          |
   |     |          expected `bool`, found `&str`

--- a/tests/trybuild-failures/not_comparison.rs
+++ b/tests/trybuild-failures/not_comparison.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use assertify::assertify;
 
 fn main() {

--- a/tests/trybuild-failures/not_comparison.stderr
+++ b/tests/trybuild-failures/not_comparison.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
- --> $DIR/not_comparison.rs:4:16
+ --> $DIR/not_comparison.rs:6:16
   |
-4 |     assertify!(1 + 2);
+6 |     assertify!(1 + 2);
   |     -----------^^^^^-
   |     |          |
   |     |          expected `bool`, found integer


### PR DESCRIPTION
The [assert2][] crate is better in pretty much every way. The only downside is that it doesn’t provide an equivalent to `testify!`, but that’s easy to reproduce with the following macro definition:

```rust
macro_rules! testify {
    ($name:ident, $($test:tt)+) => {
        #[test]
        fn $name() {
            ::assert2::assert!($($test)+);
        }
    };
}
```

[assert2]: https://crates.io/crates/assert2